### PR TITLE
Switch to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://github.com/mistydemeo/kensatsu"
 repository = "https://github.com/mistydemeo/kensatsu"
 version = "0.1.0"
 authors = ["Misty De Meo <mistydemeo@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-2.0-only"
 
 [dependencies]


### PR DESCRIPTION
This will be required for a feature I'll be using. Looks like it broke nothing.